### PR TITLE
[CTB-114, CTB-115] Serve openapi on backend server, Add basic wallet endpoints to openapi

### DIFF
--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, Flask
 from flask_cors import CORS
+from flask_swagger_ui import get_swaggerui_blueprint
 
 from .auth import AuthController
 from .database import DatabaseProvider
@@ -30,9 +31,11 @@ class Server:
     def _setup_endpoints(self) -> None:
         """Create endpoints on the Flask server."""
         self.app.add_url_rule("/", view_func=hello_world_endpoint)
+        self.swagger: Blueprint = get_swaggerui_blueprint("/api/v1/swagger", "/static/openapi.yaml")
 
         self.api: Blueprint = Blueprint("api", self.name, url_prefix="/api")
         self.v1: Blueprint = Blueprint("v1", self.name, url_prefix="/v1")
+        self.v1.register_blueprint(self.swagger, url_prefix="/swagger")
         self.v1.register_blueprint(AuthController.blueprint)
         self.v1.register_blueprint(StockMarketController.blueprint)
         self.api.register_blueprint(self.v1)

--- a/src/server/openapi.yaml
+++ b/src/server/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: CTB Backend API
-  version: 1.0.0
+  version: 1.0.1
 servers:
   - url: https://ctb-backend.onrender.com
 tags:
@@ -9,6 +9,8 @@ tags:
     description: Authentication and user management
   - name: stock
     description: Stock market data and stock price prediction
+  - name: wallet
+    description: User's wallet management [Beta]
 paths:
   /api/v1/auth/register:
     post:
@@ -159,39 +161,207 @@ paths:
       responses:
         '200':
           description: Successful operation
+  /api/v1/wallet/balance:
+    get:
+      tags:
+        - wallet
+      summary: Account balance [Beta]
+      description: Get user's account balance [Beta]
+      parameters:
+        - in: header
+          name: x-access-token
+          schema:
+            type: string
+          required: true
+          description: JWT access token
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Balance'
+        '401':
+          description: Unauthorized
+        '500':
+          description: Internal server error
+      security:
+       - JWT: []
+  /api/v1/wallet/deposit:
+    post:
+      tags:
+        - wallet
+      summary: Deposit [Beta]
+      description: Deposit cash in USD [Beta]
+      parameters:
+        - in: header
+          name: x-access-token
+          schema:
+            type: string
+          required: true
+          description: JWT access token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cash'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Invalid json format
+        '401':
+          description: Unauthorized
+        '409':
+          description: Invalid amount
+        '500':
+          description: Internal server error
+      security:
+       - JWT: []
+  /api/v1/wallet/withdraw:
+    post:
+      tags:
+        - wallet
+      summary: Withdraw [Beta]
+      description: Witdhraw cash in USD [Beta]
+      parameters:
+        - in: header
+          name: x-access-token
+          schema:
+            type: string
+          required: true
+          description: JWT access token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cash'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Invalid json format
+        '401':
+          description: Unauthorized
+        '409':
+          description: Invalid amount
+        '500':
+          description: Internal server error
+      security:
+        - JWT: []
+  /api/v1/wallet/buy:
+    post:
+      tags:
+        - wallet
+      summary: Buy [Beta]
+      description: Buy BTC cryptocurrency [Beta]
+      parameters:
+        - in: header
+          name: x-access-token
+          schema:
+            type: string
+          required: true
+          description: JWT access token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cash'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Invalid json format
+        '401':
+          description: Unauthorized
+        '409':
+          description: Invalid amount
+        '500':
+          description: Internal server error
+      security:
+        - JWT: []
+  /api/v1/wallet/sell:
+    post:
+      tags:
+        - wallet
+      summary: Sell [Beta]
+      description: Sell BTC cryptocurrency [Beta]
+      parameters:
+        - in: header
+          name: x-access-token
+          schema:
+            type: string
+          required: true
+          description: JWT access token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Cash'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+        '400':
+          description: Invalid json format
+        '401':
+          description: Unauthorized
+        '409':
+          description: Invalid amount
+        '500':
+          description: Internal server error
+      security:
+        - JWT: []
 components:
   schemas:
     User:
       type: object
       properties:
         email:
-          type: str
+          type: string
           example: user@email.com
         password:
-          type: str
+          type: string
           example: password
     Me:
       type: object
       properties:
         uuid:
-          type: str
+          type: string
           example: user_uuid
         email:
-          type: str
+          type: string
           example: user@email.com
         wallet_usd:
-          type: str
-          example: wallet_btc
+          type: number
+          example: 0.1
         wallet_btc:
-          type: str
-          example: wallet_btc
+          type: number
+          example: 0.1
     Token:
       type: object
       properties:
         auth_token:
-          type: str
+          type: string
           example: token
-  components:
+    Balance:
+      type: object
+      properties:
+        wallet_usd:
+          type: number
+          example: 0.1
+        wallet_btc:
+          type: number
+          example: 0.1
+    Cash:
+      type: object
+      properties:
+        amount:
+          type: number
+          example: 0.1
   securitySchemes:
     JWT:
       type: http

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -5,3 +5,4 @@ pyopenssl~=23.1.0
 pyjwt~=2.6.0
 uuid~=1.30
 flask-cors~=3.0.10
+flask-swagger-ui~=4.11.1

--- a/src/server/static/openapi.yaml
+++ b/src/server/static/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: CTB Backend API
   version: 1.0.1


### PR DESCRIPTION
Changes:
[CTB-114]
* Using `flask-swagger-ui` to serve swagger on server (`/api/v1/swagger`)
* Downgraded openapi (3.1.0 -> 3.0.0) because 3.1.0 is not supported yet by `flask-swagger-ui`
* Moved openapi.yaml to static directory

[CTB-115]:
* Added wallet enpoints [Beta]
* Minor type fixes